### PR TITLE
Update grub-mkfont.c

### DIFF
--- a/util/grub-mkfont.c
+++ b/util/grub-mkfont.c
@@ -33,7 +33,7 @@
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
-#include <freetype/ftsynth.h>
+#include <ftsynth.h>
 
 void
 grub_putchar (int c)


### PR DESCRIPTION
Possible fix for bug in build
  util/grub-mkfont.c:36:30: fatal error: freetype/ftsynth.h: No such file or directory.

Bug noted in AUR comments at https://aur.archlinux.org/packages/burg-bios-bzr

Can't find a custom ftsynth.h file in repo, assuming typo.
